### PR TITLE
Update RNReactNativeAndroidScannerModule.java

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNReactNativeAndroidScannerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeAndroidScannerModule.java
@@ -8,7 +8,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import android.support.annotation.Nullable;
-import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;


### PR DESCRIPTION
I remove import which was not used and not found during migration to androidx.